### PR TITLE
Support cyclic mover navigation

### DIFF
--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -511,8 +511,7 @@ export class RootAPI implements Types.RootAPI {
         let modalizer: Types.Modalizer | undefined;
         let groupper: Types.Groupper | undefined;
         let mover: HTMLElement | undefined;
-        let moverKey: Types.MoverKey | undefined;
-        let moverArrowsOnly: boolean | undefined;
+        let moverOptions: Types.MoverOptions | undefined;
         let isGroupperFirst: boolean | undefined;
 
         for (let e: (Node | null) = element; e; e = e.parentElement) {
@@ -527,12 +526,11 @@ export class RootAPI implements Types.RootAPI {
             }
 
             const cfk = ah.focusable?.mover;
-            if ((cfk !== undefined) && (moverKey === undefined)) {
-                moverKey = cfk;
+            if ((cfk !== undefined) && (moverOptions === undefined)) {
+                moverOptions = cfk;
 
-                if ((cfk === Types.MoverKeys.Arrows) || (cfk === Types.MoverKeys.Both)) {
+                if ((moverOptions.navigationType === Types.MoverKeys.Arrows) || (moverOptions.navigationType === Types.MoverKeys.Both)) {
                     mover = e as HTMLElement;
-                    moverArrowsOnly = cfk === Types.MoverKeys.Arrows;
                     isGroupperFirst = !!groupper;
                 }
             }
@@ -567,7 +565,7 @@ export class RootAPI implements Types.RootAPI {
             root = rootAPI._autoRootInstance;
         }
 
-        return root ? { root, modalizer, groupper, mover, moverArrowsOnly, isGroupperFirst } : undefined;
+        return root ? { root, modalizer, groupper, mover, moverOptions, isGroupperFirst } : undefined;
     }
 }
 

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -417,9 +417,9 @@ export class FocusedElementState
 
                 // cyclic navigation, focus first or last elements in the mover container respectively
                 if (isPrev) {
-                    next = ctx.mover.lastElementChild as HTMLElement;
+                    next = this._ah.focusable.findLast(ctx.mover);
                 } else {
-                    next = ctx.mover.firstElementChild as HTMLElement;
+                    next = this._ah.focusable.findFirst(ctx.mover);
                 }
             }
 

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -375,7 +375,7 @@ export class FocusedElementState
                 }
             }
 
-            let fromElement = (isTab && ctx.mover && ctx.moverArrowsOnly)
+            let fromElement = (isTab && ctx.mover && ctx.moverOptions?.navigationType === Types.MoverKeys.Arrows)
                 ? (isPrev // Find next focusable outside of the Mover container.
                     ? this._ah.focusable.findFirst(ctx.mover)
                     : this._ah.focusable.findLast(ctx.mover)
@@ -410,7 +410,17 @@ export class FocusedElementState
                 // Nowhere to move inside the current Mover.
                 e.preventDefault(); // We don't need the page to scroll when we're custom-handling
                                     // the arrows.
-                return;
+
+                if (!ctx.moverOptions?.cyclic) {
+                    return;
+                }
+
+                // cyclic navigation, focus first or last elements in the mover container respectively
+                if (isPrev) {
+                    next = ctx.mover.lastElementChild as HTMLElement;
+                } else {
+                    next = ctx.mover.firstElementChild as HTMLElement;
+                }
             }
 
             const groupper = ctx?.groupper;

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -215,22 +215,50 @@ export interface DeloserAPI {
     resume(restore?: boolean): void;
 }
 
-export interface MoverKeys {
-    Tab: 0;
-    Arrows: 1;
-    Both: 2;
+/**
+ * Declare the kinds of keyboard movers
+ */
+export enum MoverKeys {
+    /**
+     * Move within a mover block using only tab key
+     */
+    Tab,
+    /**
+     * Move within a mover block using up/left and down/right arrows
+     * 
+     * This is the only mover kind that supports cyclic navigation
+     */
+    Arrows,
+    /**
+     * Use both tab and arrow keys to move
+     */
+    Both
 }
-export type MoverKey = MoverKeys[keyof MoverKeys];
-export const MoverKeys: MoverKeys = {
-    Tab: 0,
-    Arrows: 1,
-    Both: 2
+
+/**
+ * Options to configure keyboard navigation mover API
+ */
+export type MoverOptions = {
+    /**
+     * The types of navigation required
+     * 
+     * @defaultValue MoverKey.Arrows
+     */
+    navigationType: MoverKeys;
+
+    /**
+     * Whether to allow cyclic navigation in the mover
+     * Can only be applied if navigationType is MoverKeys.Arrows
+     * 
+     * @defaultValue false
+     */
+    cyclic?: boolean;
 };
 
 export interface FocusableProps {
     isDefault?: boolean;
     isIgnored?: boolean;
-    mover?: MoverKey;
+    mover?: MoverOptions;
 }
 
 export interface FocusableAPI {
@@ -418,7 +446,7 @@ export interface AbilityHelpersContext {
     modalizer?: Modalizer;
     groupper?: Groupper;
     mover?: HTMLElement;
-    moverArrowsOnly?: boolean;
+    moverOptions?: MoverOptions;
     isGroupperFirst?: boolean;
 }
 

--- a/demo/src/demo.tsx
+++ b/demo/src/demo.tsx
@@ -22,7 +22,7 @@ class App extends React.PureComponent {
                 <div aria-label='Main' { ...getAbilityHelpersAttribute({ modalizer: { id: 'main' }, deloser: {} }) }>
                     <h1>Hello world</h1>
 
-                    <div { ...getAbilityHelpersAttribute({ focusable: { mover: AHTypes.MoverKeys.Arrows } }) }>
+                    <div { ...getAbilityHelpersAttribute({ focusable: { mover: { navigationType: AHTypes.MoverKeys.Arrows } } }) }>
                         <button>A</button>
                         <button>bunch</button>
                         <button>of</button>
@@ -35,6 +35,16 @@ class App extends React.PureComponent {
                         <button>instead</button>
                         <button>of</button>
                         <button>tabs</button>
+                    </div>
+
+                    <div { ...getAbilityHelpersAttribute({ focusable: { mover: { navigationType: AHTypes.MoverKeys.Arrows, cyclic: true } } }) }>
+                        <button>The</button>
+                        <button>same</button>
+                        <button>arrow</button>
+                        <button>navigation</button>
+                        <button>but</button>
+                        <button>is</button>
+                        <button>cyclic</button>
                     </div>
 
                     <div>


### PR DESCRIPTION
* Changes mover API to object instead of enum
* Change the typing to use enum instead of interface+const
* Add cyclic navigation check to `FocusedElement` API