### PR TITLE
Add findAll to Focusable API

### DIFF
--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -1134,18 +1134,18 @@ export class FocusableAPI implements Types.FocusableAPI {
      * Finds all focusables in a given context that satisfy an given condition
      *
      * @param context @see {@link _findElement}
+     * @param customFilter A callback that checks whether an element should be added to results
      * @param ignoreProgrammaticallyFocusable @see {@link _findElement}
      * @param ignoreModalizer @see {@link _findElement}
      * @param ignoreGroupper @see {@link _findElement}
-     * @param customFilter A callback that checks whether an element should be added to results
      * @param skipDefaultCondition skips the default condition that leverages @see {@link isFocusable}, be careful using this
      */
     findAll(
         context: HTMLElement,
+        customFilter: (el: HTMLElement) => boolean,
         includeProgrammaticallyFocusable?: boolean,
         ignoreModalizer?: boolean,
         ignoreGroupper?: boolean,
-        customFilter?: (el: HTMLElement) => boolean,
         skipDefaultCondition?: boolean
     ): HTMLElement[] {
         const acceptCondition = (el: HTMLElement): boolean => {
@@ -1153,7 +1153,7 @@ export class FocusableAPI implements Types.FocusableAPI {
                 el,
                 includeProgrammaticallyFocusable
             );
-            const customCheck = customFilter && customFilter(el);
+            const customCheck = customFilter(el);
 
             if (skipDefaultCondition) {
                 return !!customCheck;
@@ -1182,7 +1182,7 @@ export class FocusableAPI implements Types.FocusableAPI {
 
         const foundNodes: HTMLElement[] = [];
         let node: Node | null;
-        while((node = walker.nextNode())) {
+        while ((node = walker.nextNode())) {
             foundNodes.push(node as HTMLElement);
         }
 

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -294,6 +294,14 @@ export interface FocusableAPI {
         ignoreModalizer?: boolean, ignoreGroupper?: boolean): HTMLElement | null;
     findDefault(context?: HTMLElement, includeProgrammaticallyFocusable?: boolean,
         ignoreModalizer?: boolean, ignoreGroupper?: boolean): HTMLElement | null;
+    findAll(
+        context: HTMLElement,
+        customFilter: (el: HTMLElement) => boolean,
+        includeProgrammaticallyFocusable?: boolean,
+        ignoreModalizer?: boolean,
+        ignoreGroupper?: boolean,
+        skipDefaultCondition?: boolean
+    ): HTMLElement[];
 }
 
 export interface ElementVisibilities {

--- a/demo/src/demo.tsx
+++ b/demo/src/demo.tsx
@@ -83,6 +83,8 @@ class App extends React.PureComponent {
                 </div>
 
                 <Modal ref={ this._onModalRef } />
+
+                <FindAllExample />
             </div>
         );
     }
@@ -167,5 +169,30 @@ class Modal extends React.PureComponent<{}, { isVisible: boolean }> {
         this.setState({ isVisible: false });
     }
 }
+
+const FindAllExample: React.FC = () => {
+    const ref = React.useRef<HTMLDivElement>(null);
+    const [filtered, setFiltered] = React.useState<HTMLElement[]>([]);
+    React.useEffect(() => {
+        if (ref.current) {
+            const ducks = ah.focusable.findAll(ref?.current, (el: HTMLElement) => !!el.textContent?.includes('Duck'));
+            setFiltered(ducks);
+        }
+    }, []);
+
+    return (
+        <div>
+            <div>Filtered ducks: {filtered.map(item => item.textContent + ', ')} </div>
+            <div ref={ref} { ...getAbilityHelpersAttribute({ focusable: { mover: { navigationType: AHTypes.MoverKeys.Arrows } } }) }>
+                <button>Duck 1</button>
+                <button>Goose 1</button>
+                <button>Goose 2</button>
+                <button>Duck 2</button>
+                <button>Duck 3</button>
+                <button>Goose 3</button>
+            </div>
+        </div>
+    );    
+};
 
 ReactDOM.render(<App />, document.getElementById('demo'));


### PR DESCRIPTION
Adds a method `findAll` which will return all the elements in a context
of a root element with a provided custom check.

The default `isFocusable` can be skipped explicitly and the
documentation warns against doing so.