### PR TITLE
Encourage single AH instance on window

### DIFF
--- a/core/src/AbilityHelpers.ts
+++ b/core/src/AbilityHelpers.ts
@@ -177,7 +177,7 @@ export function createAbilityHelpers(win: Window, props?: Types.AbilityHelpersCo
     const ah = new AbilityHelpers(win, props);
     // @ts-ignore
     win.BE_ABLE_INSTANCE = ah;
-    return ah
+    return ah;
 }
 
 export function getOutline(ah: Types.AbilityHelpersCore): Types.OutlineAPI {
@@ -279,4 +279,13 @@ export function abilityHelpersExists(win: Window): boolean {
 
     // @ts-ignore
     return !!win.BE_ABLE_INSTANCE;
+}
+
+export function getWindowInstance(win: Window): Types.AbilityHelpersCore | null {
+    if (abilityHelpersExists(win)) {
+        // @ts-ignore
+        return win.BE_ABLE_INSTANCE;
+    }
+
+    return null;
 }

--- a/core/src/AbilityHelpers.ts
+++ b/core/src/AbilityHelpers.ts
@@ -182,15 +182,17 @@ class AbilityHelpers implements Types.AbilityHelpersCore, Types.AbilityHelpersIn
 /**
  * Creates an instance of ability helpers, returns the current window instance if it already exists
  */
-export function createAbilityHelpers(win: WindowWithAHInstance, props?: Types.AbilityHelpersCoreProps): Types.AbilityHelpersCore {
-    const existingAh = getCurrentAbilityHelpers(win);
+export function createAbilityHelpers(win: Window, props?: Types.AbilityHelpersCoreProps): Types.AbilityHelpersCore {
+    const existingAh = getCurrentAbilityHelpers(win as WindowWithAHInstance);
     if (existingAh) {
-        console.warn('Attempted to create a duplicate ability helpers instance on the window');
+        if (__DEV__) {
+            console.warn('Attempted to create a duplicate ability helpers instance on the window');
+        }
         return existingAh;
     }
 
     const ah = new AbilityHelpers(win, props);
-    win.__ahInstance= ah;
+    (win as WindowWithAHInstance).__ahInstance = ah;
     return ah;
 }
 
@@ -286,13 +288,12 @@ export function getAbilityHelpersAttribute(
     };
 }
 
-
 /**
  * Returns an instance of ability helpers if it already exists on the window 
  * @param win window instance that could contain an AH instance
  */
 export function getCurrentAbilityHelpers(win: WindowWithAHInstance): Types.AbilityHelpersCore | null {
-    if (win && win.__ahInstance) {
+    if (win?.__ahInstance) {
         return win.__ahInstance;
     }
 

--- a/core/src/AbilityHelpers.ts
+++ b/core/src/AbilityHelpers.ts
@@ -179,6 +179,9 @@ class AbilityHelpers implements Types.AbilityHelpersCore, Types.AbilityHelpersIn
     }
 }
 
+/**
+ * Creates an instance of ability helpers, returns the current window instance if it already exists
+ */
 export function createAbilityHelpers(win: WindowWithAHInstance, props?: Types.AbilityHelpersCoreProps): Types.AbilityHelpersCore {
     const existingAh = getCurrentAbilityHelpers(win);
     if (existingAh) {
@@ -284,6 +287,10 @@ export function getAbilityHelpersAttribute(
 }
 
 
+/**
+ * Returns an instance of ability helpers if it already exists on the window 
+ * @param win window instance that could contain an AH instance
+ */
 export function getCurrentAbilityHelpers(win: WindowWithAHInstance): Types.AbilityHelpersCore | null {
     if (win && win.__ahInstance) {
         return win.__ahInstance;

--- a/core/src/AbilityHelpers.ts
+++ b/core/src/AbilityHelpers.ts
@@ -292,10 +292,10 @@ export function getAbilityHelpersAttribute(
  * Returns an instance of ability helpers if it already exists on the window 
  * @param win window instance that could contain an AH instance
  */
-export function getCurrentAbilityHelpers(win: WindowWithAHInstance): Types.AbilityHelpersCore | null {
-    if (win?.__ahInstance) {
-        return win.__ahInstance;
+export function getCurrentAbilityHelpers(win: Window): Types.AbilityHelpersCore | undefined {
+    if ((win as WindowWithAHInstance)?.__ahInstance) {
+        return (win as WindowWithAHInstance).__ahInstance;
     }
 
-    return null;
+    return undefined;
 }

--- a/core/src/AbilityHelpers.ts
+++ b/core/src/AbilityHelpers.ts
@@ -293,9 +293,5 @@ export function getAbilityHelpersAttribute(
  * @param win window instance that could contain an AH instance
  */
 export function getCurrentAbilityHelpers(win: Window): Types.AbilityHelpersCore | undefined {
-    if ((win as WindowWithAHInstance)?.__ahInstance) {
-        return (win as WindowWithAHInstance).__ahInstance;
-    }
-
-    return undefined;
+    return (win as WindowWithAHInstance).__ahInstance;
 }

--- a/core/src/AbilityHelpers.ts
+++ b/core/src/AbilityHelpers.ts
@@ -49,11 +49,6 @@ class AbilityHelpers implements Types.AbilityHelpersCore, Types.AbilityHelpersIn
         this._storage = {};
         this._win = win;
 
-        // @ts-ignore
-        if (win && win.BE_ABLE_INSTANCE) {
-            throw new Error('Ability helpers already exists on this window');
-        }
-
         if (win && win.document) {
             this._unobserve = observeMutations(win.document, this, updateAbilityHelpersByAttribute);
         }
@@ -70,8 +65,6 @@ class AbilityHelpers implements Types.AbilityHelpersCore, Types.AbilityHelpersIn
         };
 
         startWeakStorageCleanup(getWindow);
-        // @ts-ignore
-        this._win.BE_ABLE_INSTANCE = this;
     }
 
     protected dispose(): void {
@@ -177,7 +170,14 @@ class AbilityHelpers implements Types.AbilityHelpersCore, Types.AbilityHelpersIn
 }
 
 export function createAbilityHelpers(win: Window, props?: Types.AbilityHelpersCoreProps): Types.AbilityHelpersCore {
-    return new AbilityHelpers(win, props);
+    if (abilityHelpersExists(win)) {
+        throw new Error(' An Ability helpers instance already exists on this window, you might use `abilityHelpersExists` to validate creation');
+    }
+
+    const ah = new AbilityHelpers(win, props);
+    // @ts-ignore
+    win.BE_ABLE_INSTANCE = ah;
+    return ah
 }
 
 export function getOutline(ah: Types.AbilityHelpersCore): Types.OutlineAPI {

--- a/core/src/AbilityHelpers.ts
+++ b/core/src/AbilityHelpers.ts
@@ -49,6 +49,11 @@ class AbilityHelpers implements Types.AbilityHelpersCore, Types.AbilityHelpersIn
         this._storage = {};
         this._win = win;
 
+        // @ts-ignore
+        if (win && win.BE_ABLE_INSTANCE) {
+            throw new Error('Ability helpers already exists on this window');
+        }
+
         if (win && win.document) {
             this._unobserve = observeMutations(win.document, this, updateAbilityHelpersByAttribute);
         }
@@ -65,6 +70,8 @@ class AbilityHelpers implements Types.AbilityHelpersCore, Types.AbilityHelpersIn
         };
 
         startWeakStorageCleanup(getWindow);
+        // @ts-ignore
+        this._win.BE_ABLE_INSTANCE = this;
     }
 
     protected dispose(): void {
@@ -263,4 +270,13 @@ export function getAbilityHelpersAttribute(
     return {
         [Types.AbilityHelpersAttributeName]: attr
     };
+}
+export function abilityHelpersExists(win: Window): boolean {
+    if (!window) {
+        // be safe and encourage user to not create an instance
+        return true;
+    }
+
+    // @ts-ignore
+    return !!win.BE_ABLE_INSTANCE;
 }

--- a/core/src/AbilityHelpers.ts
+++ b/core/src/AbilityHelpers.ts
@@ -20,7 +20,7 @@ import { clearElementCache, startWeakStorageCleanup, stopWeakStorageCleanupAndCl
 export { Types };
 
 /**
- * Extends Window to include an internal ability helpers instance
+ * Extends Window to include an internal ability helpers instance.
  */
 interface WindowWithAHInstance extends Window {
     __ahInstance?: Types.AbilityHelpersCore;
@@ -180,7 +180,7 @@ class AbilityHelpers implements Types.AbilityHelpersCore, Types.AbilityHelpersIn
 }
 
 /**
- * Creates an instance of ability helpers, returns the current window instance if it already exists
+ * Creates an instance of ability helpers, returns the current window instance if it already exists.
  */
 export function createAbilityHelpers(win: Window, props?: Types.AbilityHelpersCoreProps): Types.AbilityHelpersCore {
     const existingAh = getCurrentAbilityHelpers(win as WindowWithAHInstance);
@@ -289,8 +289,8 @@ export function getAbilityHelpersAttribute(
 }
 
 /**
- * Returns an instance of ability helpers if it already exists on the window 
- * @param win window instance that could contain an AH instance
+ * Returns an instance of ability helpers if it already exists on the window .
+ * @param win window instance that could contain an AH instance.
  */
 export function getCurrentAbilityHelpers(win: Window): Types.AbilityHelpersCore | undefined {
     return (win as WindowWithAHInstance).__ahInstance;

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -12,5 +12,6 @@ export {
     getModalizer,
     getObservedElement,
     getOutline,
+    abilityHelpersExists,
     Types
 } from './AbilityHelpers';

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -12,6 +12,6 @@ export {
     getModalizer,
     getObservedElement,
     getOutline,
-    abilityHelpersExists,
+    getCurrentAbilityHelpers,
     Types
 } from './AbilityHelpers';

--- a/demo/src/demo.tsx
+++ b/demo/src/demo.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { abilityHelpersExists, createAbilityHelpers, getAbilityHelpersAttribute, getDeloser, getModalizer, getOutline, Types as AHTypes } from 'ability-helpers';
+import { abilityHelpersExists, createAbilityHelpers, getAbilityHelpersAttribute, getDeloser, getModalizer, getOutline, Types as AHTypes, Types } from 'ability-helpers';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 

--- a/demo/src/demo.tsx
+++ b/demo/src/demo.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { createAbilityHelpers, getAbilityHelpersAttribute, getDeloser, getModalizer, getOutline, Types as AHTypes } from 'ability-helpers';
+import { abilityHelpersExists, createAbilityHelpers, getAbilityHelpersAttribute, getDeloser, getModalizer, getOutline, Types as AHTypes } from 'ability-helpers';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
@@ -19,6 +19,7 @@ class App extends React.PureComponent {
     render() {
         return (
             <div { ...getAbilityHelpersAttribute({ root: {} }) }>
+                <AHExistsExample />
                 <div aria-label='Main' { ...getAbilityHelpersAttribute({ modalizer: { id: 'main' }, deloser: {} }) }>
                     <h1>Hello world</h1>
 
@@ -119,6 +120,8 @@ class Item extends React.PureComponent<{ onClick: () => void }> {
         );
     }
 }
+
+const AHExistsExample: React.FC = () => (<div>Ability Helpers instance exists on window: {abilityHelpersExists(window).toString()}</div>);
 
 class Modal extends React.PureComponent<{}, { isVisible: boolean }> {
     private _div: HTMLDivElement | undefined;

--- a/demo/src/demo.tsx
+++ b/demo/src/demo.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { abilityHelpersExists, createAbilityHelpers, getAbilityHelpersAttribute, getDeloser, getModalizer, getOutline, Types as AHTypes} from 'ability-helpers';
+import { createAbilityHelpers, getAbilityHelpersAttribute, getCurrentAbilityHelpers, getDeloser, getModalizer, getOutline, Types as AHTypes} from 'ability-helpers';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
@@ -121,7 +121,7 @@ class Item extends React.PureComponent<{ onClick: () => void }> {
     }
 }
 
-const AHExistsExample: React.FC = () => (<div>Ability Helpers instance exists on window: {abilityHelpersExists(window).toString()}</div>);
+const AHExistsExample: React.FC = () => (<div>Ability Helpers instance exists on window: {getCurrentAbilityHelpers(window) ? 'true' : 'false'}</div>);
 
 class Modal extends React.PureComponent<{}, { isVisible: boolean }> {
     private _div: HTMLDivElement | undefined;

--- a/demo/src/demo.tsx
+++ b/demo/src/demo.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { abilityHelpersExists, createAbilityHelpers, getAbilityHelpersAttribute, getDeloser, getModalizer, getOutline, Types as AHTypes, Types } from 'ability-helpers';
+import { abilityHelpersExists, createAbilityHelpers, getAbilityHelpersAttribute, getDeloser, getModalizer, getOutline, Types as AHTypes} from 'ability-helpers';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 


### PR DESCRIPTION
* Adds internal window instance of AH on creation
* Added  `abilityHelpersExists` helper method
* Throw error on `createAbilityHelpers` if an AH instance already exists on the window